### PR TITLE
Remove NITE as a system dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,20 +11,10 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs
 find_package(PkgConfig)
 pkg_check_modules(OpenNI REQUIRED libopenni)
 
-# Find Nite
-find_path(Nite_INCLUDEDIR
-	  NAMES XnVNite.h
-	  HINTS /usr/include/nite /usr/local/include/nite)
-find_library(Nite_LIBRARY
-	     NAMES XnVNite_1_3_1
-	     HINTS /usr/lib /usr/local/lib
-	     PATH_SUFFIXES lib) 
-
 catkin_package()
 
 include_directories(${catkin_INCLUDEDIR}
 		    ${OpenNI_INCLUDEDIR}
-		    ${Nite_INCLUDEDIR}
 		    ${orocos_kdl_INCLUDE_DIRS})
 
 link_directories(${catkin_LIBRARY_DIRS})
@@ -36,7 +26,6 @@ add_dependencies(openni_tracker geometry_msgs_gencpp)
 
 target_link_libraries(openni_tracker ${catkin_LIBRARIES}
 				     ${OpenNI_LIBRARIES}
-				     ${Nite_LIBRARY}
 				     ${orocos_kdl_LIBRARIES})
 
 install(TARGETS openni_tracker RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 The OpenNI tracker broadcasts the OpenNI skeleton frames using tf.
 For more information checkout the ROS Wiki: http://ros.org/wiki/openni_tracker
 
+#NITE Information
+
+The NITE library must be manually installed for openni_tracker to function.  The two versions that are compatible with this package are 1.5.2.21 and 1.5.2.23.
+
+NITE v1.5.2.23 can currently be downloaded from [http://www.openni.ru/openni-sdk/openni-sdk-history-2/](http://www.openni.ru/openni-sdk/openni-sdk-history-2/)
+

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,6 @@
 
   <build_depend>libopenni-dev</build_depend>
   <build_depend>libusb-1.0-dev</build_depend>
-  <build_depend>libopenni-nite-dev</build_depend>
   <build_depend>libopenni-sensor-primesense-dev</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>orocos_kdl</build_depend>
@@ -22,7 +21,6 @@
 
   <run_depend>libopenni-dev</run_depend>
   <run_depend>libusb-1.0-dev</run_depend>
-  <run_depend>libopenni-nite-dev</run_depend>
   <run_depend>libopenni-sensor-primesense-dev</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>orocos_kdl</run_depend>

--- a/src/openni_tracker.cpp
+++ b/src/openni_tracker.cpp
@@ -147,7 +147,10 @@ int main(int argc, char **argv) {
 	nRetVal = g_Context.FindExistingNode(XN_NODE_TYPE_USER, g_UserGenerator);
 	if (nRetVal != XN_STATUS_OK) {
 		nRetVal = g_UserGenerator.Create(g_Context);
-		CHECK_RC(nRetVal, "Find user generator");
+	    if (nRetVal != XN_STATUS_OK) {
+		    ROS_ERROR("NITE is likely missing: Please install NITE >= 1.5.2.21. Check the readme for download information. Error Info: User generator failed: %s", xnGetStatusString(nRetVal));
+            return nRetVal;
+	    }
 	}
 
 	if (!g_UserGenerator.IsCapabilitySupported(XN_CAPABILITY_SKELETON)) {


### PR DESCRIPTION
This PR addresses issues #6 and #7 since NITE is technically not allowed to be repackaged anymore.  Openni_tracker does not need to be linked to NITE libraries, so having users manually post-install NITE works fine.  When NITE is not installed, an error message directs users to the README for download locations.  This should also allow release into Indigo which doesn't provide libopenni-nite-dev.
