### PR TITLE
fix CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ pkg_check_modules(OpenNI REQUIRED libopenni)
 
 catkin_package()
 
-include_directories(${catkin_INCLUDEDIR}
+include_directories(${catkin_INCLUDE_DIRS}
 		    ${OpenNI_INCLUDEDIR}
 		    ${orocos_kdl_INCLUDE_DIRS})
 


### PR DESCRIPTION
Old CMake variable `catkin_INCLUDEDIR` is empty and compilation is failed.
Make cannot find `ros/ros.h`

Replacing `catkin_INCLUDEDIR` by `catkin_INCLUDE_DIRS` solved this problem